### PR TITLE
[#1]feat: 회원가입 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### local properties ###
+*-local.*

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,17 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/baroassignment/domain/User.java
+++ b/src/main/java/com/example/baroassignment/domain/User.java
@@ -1,0 +1,23 @@
+package com.example.baroassignment.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+public class User {
+    private String username;
+    private String nickname;
+    private String password;
+    private List<Map<String, String>> roles = new ArrayList<>();
+
+    public User(String username, String nickname, String encodedPassword){
+        this.username=username;
+        this.nickname=nickname;
+        this.password=encodedPassword;
+    }
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.example.baroassignment.domain.auth.controller;
+
+import com.example.baroassignment.domain.auth.dto.request.SignupRequest;
+import com.example.baroassignment.domain.auth.dto.response.SignupResponse;
+import com.example.baroassignment.domain.auth.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest signupRequest){
+
+        return new ResponseEntity<>(authService.signup(signupRequest), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/AuthUser.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/AuthUser.java
@@ -1,4 +1,17 @@
 package com.example.baroassignment.domain.auth.dto;
 
+import lombok.Getter;
+
+@Getter
 public class AuthUser {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+
+    public AuthUser(Long id, String email, String nickname) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/request/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.example.baroassignment.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupRequest {
+
+    private String username;
+
+    private String password;
+
+    private String nickname;
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/response/SignupResponse.java
@@ -1,0 +1,15 @@
+package com.example.baroassignment.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class SignupResponse {
+    private String username;
+    private String  nickname;
+    private List<Map<String, String>> roles;
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/service/AuthService.java
@@ -1,0 +1,50 @@
+package com.example.baroassignment.domain.auth.service;
+
+import com.example.baroassignment.domain.User;
+import com.example.baroassignment.domain.auth.dto.request.SignupRequest;
+import com.example.baroassignment.domain.auth.dto.response.SignupResponse;
+import com.example.baroassignment.global.exception.CustomException;
+import com.example.baroassignment.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final Map<Long, User> userRepository = new HashMap<>();
+    private static Long nextId = 1L;
+
+    public SignupResponse signup(SignupRequest signupRequest) {
+        if (isUserNameAlreadyRegistered(signupRequest.getUsername())){
+            throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
+        }
+        String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
+        User user = new User(
+                signupRequest.getUsername(),
+                signupRequest.getNickname(),
+                encodedPassword
+        );
+        Map<String, String> roles = new HashMap<>();
+        if(nextId == 1L){
+            roles.put("role","ROLE_ADMIN");
+        }
+        else{
+            roles.put("role","ROLE_USER");
+        }
+        user.getRoles().add(roles);
+        userRepository.put(nextId,user);
+        nextId++;
+        return new SignupResponse(user.getUsername(),user.getNickname(),user.getRoles());
+    }
+
+    private boolean isUserNameAlreadyRegistered(String username) {
+        return userRepository.values().stream()
+                .anyMatch(user -> user.getUsername().equals(username));
+    }
+}

--- a/src/main/java/com/example/baroassignment/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/baroassignment/global/config/SecurityConfig.java
@@ -1,4 +1,51 @@
 package com.example.baroassignment.global.config;
 
+import com.example.baroassignment.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)    //@Secured 어노테이션 사용 가능
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, SecurityContextHolderAwareRequestFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(request -> request.getRequestURI().startsWith("/api/v1/auth")).permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers(("/auth/admin/**")).hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
 }

--- a/src/main/java/com/example/baroassignment/global/exception/CustomException.java
+++ b/src/main/java/com/example/baroassignment/global/exception/CustomException.java
@@ -1,0 +1,24 @@
+package com.example.baroassignment.global.exception;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Slf4j
+@Getter
+public class CustomException extends RuntimeException {
+    private final HttpStatus status;
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getStatus();
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " " + message);
+        this.status = errorCode.getStatus();
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/baroassignment/global/exception/CustomExceptionResponse.java
+++ b/src/main/java/com/example/baroassignment/global/exception/CustomExceptionResponse.java
@@ -1,0 +1,18 @@
+package com.example.baroassignment.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CustomExceptionResponse {
+
+    private final ErrorInfo error;
+
+
+    public CustomExceptionResponse(ErrorCode errorCode) {
+        this.error = new ErrorInfo(errorCode.name(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/example/baroassignment/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/baroassignment/global/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.baroassignment.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // U
+    USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),
+    UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/baroassignment/global/exception/ErrorInfo.java
+++ b/src/main/java/com/example/baroassignment/global/exception/ErrorInfo.java
@@ -1,0 +1,11 @@
+package com.example.baroassignment.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorInfo {
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/baroassignment/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/baroassignment/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.example.baroassignment.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomExceptionResponse> handleCustomException(CustomException e) {
+        return getErrorResponse(e.getStatus(), e.getErrorCode());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CustomExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String firstErrorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("유효성 검사 오류가 발생했습니다.");
+        // MethodArgumentNotValidException에 대한 ErrorCode 정의 (예시)
+        return getErrorResponse(HttpStatus.BAD_REQUEST, ErrorCode.UNKNOWN);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomExceptionResponse> handleAllExceptions(Exception e) {
+        return getErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN);
+    }
+
+    private ResponseEntity<CustomExceptionResponse> getErrorResponse(HttpStatus status, ErrorCode errorCode) {
+        CustomExceptionResponse response = new CustomExceptionResponse(errorCode);
+        return new ResponseEntity<>(response, status);
+    }
+}

--- a/src/main/java/com/example/baroassignment/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/baroassignment/global/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
-package com.fifteen.auction.domain.user.auth.filter;
+package com.example.baroassignment.global.jwt;
 
-import com.fifteen.auction.domain.user.auth.entity.AuthUser;
-import com.fifteen.auction.domain.user.auth.util.JwtUtil;
+
+import com.example.baroassignment.domain.auth.dto.AuthUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -37,11 +37,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull FilterChain chain
     ) throws ServletException, IOException {
 
-        // /api/v1/auth/** 경로는 JWT 검증 없이 통과
-         if (httpRequest.getRequestURI().startsWith("/api/v1/auth")) {
-            chain.doFilter(httpRequest, httpResponse);
-            return;
-         }
+
+//         if (httpRequest.getRequestURI().startsWith("auth")) {
+//            chain.doFilter(httpRequest, httpResponse);
+//            return;
+//         }
 
         String authorizationHeader = httpRequest.getHeader("Authorization");
 

--- a/src/main/java/com/example/baroassignment/global/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/example/baroassignment/global/jwt/JwtAuthenticationToken.java
@@ -1,6 +1,6 @@
-package com.fifteen.auction.domain.user.auth.filter;
+package com.example.baroassignment.global.jwt;
 
-import com.fifteen.auction.domain.user.auth.entity.AuthUser;
+import com.example.baroassignment.domain.auth.dto.AuthUser;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
 import java.util.Collections;
@@ -10,7 +10,7 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     private final AuthUser authUser;
 
     public JwtAuthenticationToken(AuthUser authUser) {
-        super(Collections.emptyList());  // 권한 없이 인증 처리
+        super(Collections.emptyList());
         this.authUser = authUser;
         setAuthenticated(true);
     }

--- a/src/main/java/com/example/baroassignment/global/jwt/JwtUtil.java
+++ b/src/main/java/com/example/baroassignment/global/jwt/JwtUtil.java
@@ -1,4 +1,5 @@
-package com.fifteen.auction.domain.user.auth.util;
+package com.example.baroassignment.global.jwt;
+
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -19,8 +20,7 @@ import java.util.Date;
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
-    private static final long REFRESH_TOKEN_TIME = 14 * 24 * 60 * 60 * 1000L; // 14일
+    private static final long TOKEN_TIME = 60 * 120 * 1000L;
 
     @Value("${jwt.secret.key}")
     private String secretKey;
@@ -43,27 +43,9 @@ public class JwtUtil {
                         .claim("nickname", nickname)
                         .claim("role", role)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
-                        .setIssuedAt(date) // 발급일
-                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
-                        .compact();
-    }
-
-    // Refresh Token 생성
-    public String createRefreshToken(Long userId) {
-        Date now = new Date();
-
-        return BEARER_PREFIX +
-                Jwts.builder()
-                        .setSubject(String.valueOf(userId)) //refresh token 내에 최소한의 정보만 넣는 것이 일반적.
-                        .setIssuedAt(now)
-                        .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_TIME))
+                        .setIssuedAt(date)
                         .signWith(key, signatureAlgorithm)
                         .compact();
-    }
-
-    // Refresh Token 유효 시간 반환 (ms)
-    public long getRefreshTokenExpiry() {
-        return REFRESH_TOKEN_TIME;
     }
 
     public String substringToken(String tokenValue) {
@@ -81,14 +63,12 @@ public class JwtUtil {
                 .getBody();
     }
 
-    // 토큰의 남은 만료 시간 계산 (ms 단위)
     public Long getTokenExpiration(String token) {
         Claims claims = extractClaims(token);
         Date expiration = claims.getExpiration();
         return expiration.getTime() - System.currentTimeMillis();
     }
 
-    // 토큰 유효성 검사 (예외 발생 시 false)
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
@@ -97,11 +77,5 @@ public class JwtUtil {
             log.warn("Invalid JWT Token: {}", e.getMessage());
             return false;
         }
-    }
-
-    // RefreshToken에서 사용자 ID 추출
-    public Long extractUserId(String token) {
-        Claims claims = extractClaims(token);
-        return Long.parseLong(claims.getSubject());
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,3 @@
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=BaroAssignment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: assignment


### PR DESCRIPTION
### 구현사항

- /auth/signup POST API 엔드포인트 추가 (아이디, 닉네임, 비밀번호)
- AuthService에 회원가입 로직 구현 (중복 확인, 비밀번호 암호화, 사용자 저장, 권한 부여)
- 첫 번째 가입자는 ROLE_ADMIN, 이후 가입자는 ROLE_USER 권한 부여
- username 중복 시 USER_ALREADY_EXISTS 에러 처리