### PR TITLE
[#3] feat: 로그인 기능 구현

### DIFF
--- a/src/main/java/com/example/baroassignment/domain/User.java
+++ b/src/main/java/com/example/baroassignment/domain/User.java
@@ -1,5 +1,6 @@
 package com.example.baroassignment.domain;
 
+import com.example.baroassignment.domain.auth.enums.UserRole;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,14 +11,22 @@ import java.util.Map;
 @Getter
 @Setter
 public class User {
+    private Long id;
     private String username;
     private String nickname;
     private String password;
-    private List<Map<String, String>> roles = new ArrayList<>();
+    private UserRole role;
 
-    public User(String username, String nickname, String encodedPassword){
-        this.username=username;
-        this.nickname=nickname;
-        this.password=encodedPassword;
+
+    public User(Long id,String username, String nickname, String encodedPassword){
+        this.id = id;
+        this.username = username;
+        this.nickname = nickname;
+        this.password = encodedPassword;
+        if(id == 1L){
+            this.role=UserRole.ROLE_ADMIN;
+        }else{
+            this.role=UserRole.ROLE_USER;
+        }
     }
 }

--- a/src/main/java/com/example/baroassignment/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.example.baroassignment.domain.auth.controller;
 
+import com.example.baroassignment.domain.auth.dto.request.SigninRequest;
 import com.example.baroassignment.domain.auth.dto.request.SignupRequest;
+import com.example.baroassignment.domain.auth.dto.response.SigninResponse;
 import com.example.baroassignment.domain.auth.dto.response.SignupResponse;
 import com.example.baroassignment.domain.auth.service.AuthService;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,5 +26,10 @@ public class AuthController {
     public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest signupRequest){
 
         return new ResponseEntity<>(authService.signup(signupRequest), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<SigninResponse> signin(@RequestBody SigninRequest signinRequest){
+        return new ResponseEntity<>(authService.signin(signinRequest), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/request/SigninRequest.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/request/SigninRequest.java
@@ -1,0 +1,12 @@
+package com.example.baroassignment.domain.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SigninRequest {
+    private final String username;
+    
+    private final String password;
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/response/SigninResponse.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/response/SigninResponse.java
@@ -1,0 +1,10 @@
+package com.example.baroassignment.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SigninResponse {
+    private final String token;
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/response/SignupResponse.java
@@ -1,8 +1,10 @@
 package com.example.baroassignment.domain.auth.dto.response;
 
+import com.example.baroassignment.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -10,6 +12,16 @@ import java.util.Map;
 @AllArgsConstructor
 public class SignupResponse {
     private String username;
-    private String  nickname;
+    private String nickname;
     private List<Map<String, String>> roles;
+
+    public static SignupResponse from(User user) {
+        Map<String, String> roleMap = new HashMap<>();
+        roleMap.put("role", user.getRole().name());
+        return new SignupResponse(
+                user.getUsername(),
+                user.getNickname(),
+                List.of(roleMap)
+        );
+    }
 }

--- a/src/main/java/com/example/baroassignment/domain/auth/enums/UserRole.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/enums/UserRole.java
@@ -1,0 +1,7 @@
+package com.example.baroassignment.domain.auth.enums;
+
+
+public enum UserRole {
+    ROLE_USER,
+    ROLE_ADMIN;
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.example.baroassignment.domain.auth.service;
 
 import com.example.baroassignment.domain.User;
+import com.example.baroassignment.domain.auth.dto.request.SigninRequest;
 import com.example.baroassignment.domain.auth.dto.request.SignupRequest;
+import com.example.baroassignment.domain.auth.dto.response.SigninResponse;
 import com.example.baroassignment.domain.auth.dto.response.SignupResponse;
+import com.example.baroassignment.global.config.IdGenerator;
 import com.example.baroassignment.global.exception.CustomException;
 import com.example.baroassignment.global.exception.ErrorCode;
+import com.example.baroassignment.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,9 +20,10 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final JwtUtil jwtUtil;
+    private final IdGenerator idGenerator;
     private final PasswordEncoder passwordEncoder;
     private final Map<Long, User> userRepository = new HashMap<>();
-    private static Long nextId = 1L;
 
     public SignupResponse signup(SignupRequest signupRequest) {
         if (isUserNameAlreadyRegistered(signupRequest.getUsername())){
@@ -26,21 +31,34 @@ public class AuthService {
         }
         String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
         User user = new User(
+                idGenerator.generateId(),
                 signupRequest.getUsername(),
                 signupRequest.getNickname(),
                 encodedPassword
         );
-        Map<String, String> roles = new HashMap<>();
-        if(nextId == 1L){
-            roles.put("role","ROLE_ADMIN");
+
+        userRepository.put(user.getId(),user);
+        return SignupResponse.from(user);
+    }
+
+    public SigninResponse signin(SigninRequest signinRequest) {
+        User user = userRepository.values().stream()
+                .filter(u -> u.getUsername().equals(signinRequest.getUsername()))
+                .findFirst()
+                .orElseThrow(()-> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        if(!passwordEncoder.matches(signinRequest.getPassword(),user.getPassword())){
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
-        else{
-            roles.put("role","ROLE_USER");
-        }
-        user.getRoles().add(roles);
-        userRepository.put(nextId,user);
-        nextId++;
-        return new SignupResponse(user.getUsername(),user.getNickname(),user.getRoles());
+        String token = jwtUtil.createToken(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getRole().toString()
+        );
+        token = jwtUtil.substringToken(token);
+
+        return new SigninResponse(token);
     }
 
     private boolean isUserNameAlreadyRegistered(String username) {

--- a/src/main/java/com/example/baroassignment/global/config/IdGenerator.java
+++ b/src/main/java/com/example/baroassignment/global/config/IdGenerator.java
@@ -1,0 +1,11 @@
+package com.example.baroassignment.global.config;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdGenerator {
+    private long nextId = 1L;
+    public synchronized long generateId() {
+        return nextId++;
+    }
+}

--- a/src/main/java/com/example/baroassignment/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/baroassignment/global/exception/ErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    // I
+    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST,"아이디 또는 비밀번호가 올바르지 않습니다."),
+
     // U
     USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),
     UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다.");

--- a/src/main/java/com/example/baroassignment/global/jwt/JwtUtil.java
+++ b/src/main/java/com/example/baroassignment/global/jwt/JwtUtil.java
@@ -39,7 +39,7 @@ public class JwtUtil {
         return BEARER_PREFIX +
                 Jwts.builder()
                         .setSubject(String.valueOf(userId))
-                        .claim("email", email)
+                        .claim("username", email)
                         .claim("nickname", nickname)
                         .claim("role", role)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))


### PR DESCRIPTION
## 구현사항
- /auth/signin POST API 엔드포인트 추가 (아이디, 비밀번호)
- AuthService에 로그인 로직 구현 (아이디 - 비밀번호 일치여부 확인, 토큰발행 )
- 로그인 실패시 INVALID_CREDENTIALS 에러 처리

## 변경사항
권한을 UserRole Enum을 사용하도록 수정
IdGenerator 추가


closed #3  