### PR TITLE
[#5] feat: 관리자 권한 부여 API 구현

### DIFF
--- a/src/main/java/com/example/baroassignment/domain/User.java
+++ b/src/main/java/com/example/baroassignment/domain/User.java
@@ -4,10 +4,6 @@ import com.example.baroassignment.domain.auth.enums.UserRole;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 @Getter
 @Setter
 public class User {
@@ -27,6 +23,12 @@ public class User {
             this.role=UserRole.ROLE_ADMIN;
         }else{
             this.role=UserRole.ROLE_USER;
+        }
+    }
+
+    public void updateToAdmin(){
+        if (this.role != UserRole.ROLE_ADMIN) {
+            this.role = UserRole.ROLE_ADMIN;
         }
     }
 }

--- a/src/main/java/com/example/baroassignment/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/baroassignment/domain/admin/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.example.baroassignment.domain.admin.controller;
+
+import com.example.baroassignment.domain.admin.service.AdminService;
+import com.example.baroassignment.domain.auth.dto.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PatchMapping("/users/{userId}/roles")
+    public ResponseEntity<UserResponse> grantAdminRole(@PathVariable Long userId){
+        log.info("userId={}",userId);
+        return new ResponseEntity<>(adminService.grantAdminRole(userId), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/baroassignment/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/baroassignment/domain/admin/service/AdminService.java
@@ -1,0 +1,20 @@
+package com.example.baroassignment.domain.admin.service;
+
+import com.example.baroassignment.domain.User;
+import com.example.baroassignment.domain.auth.dto.response.UserResponse;
+import com.example.baroassignment.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+
+    public UserResponse grantAdminRole(Long userId) {
+        User user = userRepository.findById(userId);
+        user.updateToAdmin();
+        return UserResponse.from(user);
+    }
+}

--- a/src/main/java/com/example/baroassignment/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/controller/AuthController.java
@@ -3,9 +3,9 @@ package com.example.baroassignment.domain.auth.controller;
 import com.example.baroassignment.domain.auth.dto.request.SigninRequest;
 import com.example.baroassignment.domain.auth.dto.request.SignupRequest;
 import com.example.baroassignment.domain.auth.dto.response.SigninResponse;
-import com.example.baroassignment.domain.auth.dto.response.SignupResponse;
+import com.example.baroassignment.domain.auth.dto.response.UserResponse;
 import com.example.baroassignment.domain.auth.service.AuthService;
-import org.apache.coyote.Response;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,15 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
 
     @PostMapping("/signup")
-    public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest signupRequest){
+    public ResponseEntity<UserResponse> signup(@RequestBody SignupRequest signupRequest){
 
         return new ResponseEntity<>(authService.signup(signupRequest), HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/AuthUser.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/AuthUser.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 public class AuthUser {
 
     private final Long id;
-    private final String email;
+    private final String username;
     private final String nickname;
 
-    public AuthUser(Long id, String email, String nickname) {
+    public AuthUser(Long id, String username, String nickname) {
         this.id = id;
-        this.email = email;
+        this.username = username;
         this.nickname = nickname;
     }
 }

--- a/src/main/java/com/example/baroassignment/domain/auth/dto/response/UserResponse.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/dto/response/UserResponse.java
@@ -10,15 +10,15 @@ import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public class SignupResponse {
+public class UserResponse {
     private String username;
     private String nickname;
     private List<Map<String, String>> roles;
 
-    public static SignupResponse from(User user) {
+    public static UserResponse from(User user) {
         Map<String, String> roleMap = new HashMap<>();
         roleMap.put("role", user.getRole().name());
-        return new SignupResponse(
+        return new UserResponse(
                 user.getUsername(),
                 user.getNickname(),
                 List.of(roleMap)

--- a/src/main/java/com/example/baroassignment/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/example/baroassignment/domain/auth/repository/UserRepository.java
@@ -1,0 +1,32 @@
+package com.example.baroassignment.domain.auth.repository;
+
+import com.example.baroassignment.domain.User;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class UserRepository {
+    private final Map<Long, User> repository = new HashMap<>();
+
+    public User findById(Long id) {
+        return repository.get(id);
+    }
+
+    public void save(User user) {
+        repository.put(user.getId(), user);
+    }
+
+    public Optional<User> findByUsername(String username) {
+        return repository.values().stream()
+                .filter(u -> u.getUsername().equals(username))
+                .findFirst();
+    }
+
+    public Collection<User> findAll() {
+        return repository.values();
+    }
+}

--- a/src/main/java/com/example/baroassignment/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/baroassignment/global/exception/GlobalExceptionHandler.java
@@ -26,12 +26,12 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .map(FieldError::getDefaultMessage)
                 .orElse("유효성 검사 오류가 발생했습니다.");
-        // MethodArgumentNotValidException에 대한 ErrorCode 정의 (예시)
         return getErrorResponse(HttpStatus.BAD_REQUEST, ErrorCode.UNKNOWN);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<CustomExceptionResponse> handleAllExceptions(Exception e) {
+        log.error("Exception", e);
         return getErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN);
     }
 

--- a/src/main/java/com/example/baroassignment/global/jwt/JwtUtil.java
+++ b/src/main/java/com/example/baroassignment/global/jwt/JwtUtil.java
@@ -33,13 +33,13 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, String nickname, String role) {
+    public String createToken(Long userId, String username, String nickname, String role) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .setSubject(String.valueOf(userId))
-                        .claim("username", email)
+                        .claim("username", username)
                         .claim("nickname", nickname)
                         .claim("role", role)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))


### PR DESCRIPTION
### 구현사항
- /admin/users/{userId}/roles PATCH API 엔드포인트 추가 (관리자 권한 부여)
- AdminService에 관리자 권한 부여 로직 구현
- ROLE_ADMIN 권한 없을시 AccessDeniedHandler에서 예외 응답

### 변경사항
- jwt 필터에서 예외를 json으로 응답하도록 수정
- UserRepository를 별도의 클래스로 분리

closed #5 